### PR TITLE
Specify settings path

### DIFF
--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.cpp
@@ -344,6 +344,7 @@ void ASimHUD::initializeSubWindows()
 
 // Attempts to parse the settings text from one of multiple locations.
 // First, check the command line for settings provided via "-s" or "--settings" arguments
+// Next, check the command line for settings file path provided via "--airsim" argument.
 // Next, check the executable's working directory for the settings file.
 // Finally, check the user's documents folder. 
 // If the settings file cannot be read, throw an exception
@@ -351,6 +352,8 @@ void ASimHUD::initializeSubWindows()
 bool ASimHUD::getSettingsText(std::string& settingsText) 
 {
     return (getSettingsTextFromCommandLine(settingsText)
+        ||
+        readSettingsTextFromFile(FString(getSettingsFilePathFromCommandLine("settings.json").c_str()), settingsText)
         ||
         readSettingsTextFromFile(FString(msr::airlib::Settings::getExecutableFullPath("settings.json").c_str()), settingsText)
         ||
@@ -379,6 +382,21 @@ bool ASimHUD::getSettingsTextFromCommandLine(std::string& settingsText)
     }
 
     return found;
+}
+
+std::string ASimHUD::getSettingsFilePathFromCommandLine(std::string fileName)
+{
+    std::string path;
+    FString settingsTextFStringParsed;
+    const TCHAR* commandLineArgs = FCommandLine::Get();
+
+    if (FParse::Param(commandLineArgs, TEXT("-airsim"))) {
+        FString commandLineArgsFString = FString(commandLineArgs);
+        int idx = commandLineArgsFString.Find(TEXT("-airsim"));
+        FString settingFilePath = commandLineArgsFString.RightChop(idx + 8);
+        path = common_utils::FileSystem::combine(std::string(TCHAR_TO_UTF8(*settingFilePath)), fileName);
+    }
+    return path;
 }
 
 bool ASimHUD::readSettingsTextFromFile(FString settingsFilepath, std::string& settingsText) 

--- a/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.h
+++ b/Unreal/Plugins/AirSim/Source/SimHUD/SimHUD.h
@@ -66,6 +66,7 @@ private:
 
     bool getSettingsText(std::string& settingsText);
     bool getSettingsTextFromCommandLine(std::string& settingsText);
+    std::string getSettingsFilePathFromCommandLine(std::string fileName);
     bool readSettingsTextFromFile(FString fileName, std::string& settingsText);
     std::string getSimModeFromUser();
 

--- a/build.sh
+++ b/build.sh
@@ -20,7 +20,7 @@ if [[ ! -d "llvm-source-50" ]]; then
 fi
 
 # check for libc++
-if [[ !(-d "./llvm-build/output/lib") ]]; then
+if [[ ! (-d "./llvm-build/output/lib") ]]; then
     echo "ERROR: clang++ and libc++ is necessary to compile AirSim and run it in Unreal engine"
     echo "Please run setup.sh first."
     exit 1
@@ -60,7 +60,7 @@ else
 fi
 
 #install EIGEN library
-if [[ !(-d "./AirLib/deps/eigen3/Eigen") ]]; then 
+if [[ ! (-d "./AirLib/deps/eigen3/Eigen") ]]; then 
     echo "eigen is not installed. Please run setup.sh first."
     exit 1
 fi


### PR DESCRIPTION
Specify AirSim settings.json location path by using the `airsim` command line argument.